### PR TITLE
Feature/slidedates

### DIFF
--- a/Page.html
+++ b/Page.html
@@ -56,6 +56,17 @@
       </form>
     </div>
 
+    <!-- add by Nute16 -->
+    <div class="block form-group">
+      <label id="SlideDates"></label>
+      <form name="setSlideDays">
+        <input name="slideDays" type="number" style="width: 50px"> days
+        <div>
+        <input type="button" class="action" value="" onclick="send_slideDates();">
+        </div>
+      </form>
+    </div>
+
     <div class="block form-group">
       <label id="Recal"></label>
       <form name="recalculate">
@@ -114,6 +125,7 @@
     var linkHowto = lang === 'ja' ? 'http://takuya0206.hateblo.jp/entry/ganttchart_generator' : 'https://github.com/takuya0206/ganttchart_generator';
     var textTitle = lang === 'ja' ? 'ガントチャートの操作' : 'Edit Gantt Chart';
     var textSetStart = lang === 'ja' ? 'ガントチャートの開始日と表示期間を変更' : 'Change Start Date and Chart Width';
+    var textSlideDates = lang === 'ja' ? '選択範囲内の日付をスライド（+/-）' : 'Slide the date within the selected range(+/-)';//add by Nute16
     var textRecal = lang === 'ja' ? '工数（予）と進捗の再計算' : 'Recalculate Workload (plan) & Progress';
     var textRedo = lang === 'ja' ? 'ガントチャートの再色塗り' : 'Repaint Gantt Chart';
     var textReset = lang === 'ja' ? 'ガンチャートの初期化' : 'Initalize Gantt Chart';
@@ -133,6 +145,7 @@
     $('#Howto').attr("href", linkHowto);
     $('#Title').text(textTitle);
     $('#SetStart').text(textSetStart);
+    $('#SlideDates').text(textSlideDates);// add by Nute16
     $('#Recal').text(textRecal);
     $('#Redo').text(textRedo);
     $('#Reset').text(textReset);
@@ -217,6 +230,20 @@
         .withFailureHandler(errorMsg)
         .formatGantchart(7, formObj.startDate.value, num);
       };
+    };
+
+    // add by Nute16
+    function send_slideDates(){
+      var days = document.forms.setSlideDays.slideDays.value;
+      startWait();
+      google.script.run
+      .withSuccessHandler(successMsg)
+      .withFailureHandler(errorMsg)
+      .slideDates(days);
+      google.script.run
+      .withSuccessHandler(successMsg)
+      .withFailureHandler(errorMsg)
+      .front_updateChart();
     };
 
     $('#Donation').on( 'click', function(){

--- a/Page.html
+++ b/Page.html
@@ -33,6 +33,11 @@
  text-decoration: underline;
 }
 
+.bottom {
+  position: fixed;
+  bottom: 15px;
+}
+
 </style>
 </head>
 <body>

--- a/Page.html
+++ b/Page.html
@@ -234,16 +234,21 @@
 
     // add by Nute16
     function send_slideDates(){
-      var days = document.forms.setSlideDays.slideDays.value;
-      startWait();
-      google.script.run
-      .withSuccessHandler(successMsg)
-      .withFailureHandler(errorMsg)
-      .slideDates(days);
-      google.script.run
-      .withSuccessHandler(successMsg)
-      .withFailureHandler(errorMsg)
-      .front_updateChart();
+      var days = parseInt(document.forms.setSlideDays.slideDays.value);
+      if(days){
+        startWait();
+        google.script.run
+        .withSuccessHandler(successMsg)
+        .withFailureHandler(errorMsg)
+        .slideDates(days);
+        startWait();
+        google.script.run
+        .withSuccessHandler(successMsg)
+        .withFailureHandler(errorMsg)
+        .front_updateChart();
+      }else{
+        return;
+      }
     };
 
     $('#Donation').on( 'click', function(){

--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ A column | Date | Make a holiday line in pink
 
 ### Sidebar
 
-Item           | Actio
+Item           | Action
 ------------ | --------------------------
 Change Start Date and Chart Width       | Change start date<br />Change chart width in week
+Slide the Date within the Selected Range | Slide the date within the cell <br/>  After the process, it repaints the Gantt chart <br/> (*)When multiple ranges are selected, only the last selected range will be processed<!--add by Nute16-->
 Recalculate Workload (plan) & Progress | Calculate all parents' worklaod and progress
 Repaint Gantt Chart | Repaint all of the Chart
 Show Color Indication      | Indicate progress like blue means "completed" or "not start," yellow means "in progress" and red means "delayed"

--- a/functions.gs
+++ b/functions.gs
@@ -963,3 +963,24 @@ function makeParentBold(data, range){
  };
  range.setFontWeights(info);
 };
+
+/**
+ * This function slide the date within the selected cell by the number of days set in the side menu. After the process, you need repaint the Gantt chart.
+ * (Nodes) When multiple ranges are selected, only the last selected range will be processed.This is due to the specification of getActiveRange ().
+ * @param  {integer} days [Number of days set in the side menu.]
+ */
+function slideDates(days) {
+  Logger.log('slideDates start');
+  var range = SpreadsheetApp.getActiveRange();
+  var cells = range.getValues();
+  var rowLen = range.getNumRows();
+  var columnLen = range.getNumColumns();
+  for (var i = 0; i < rowLen; i++) {
+    for (var j = 0; j < columnLen; j++) {
+      if (toString.call(cells[i][j]).slice(8, -1).toLowerCase() == 'date') {
+        cells[i][j].setDate(cells[i][j].getDate() + days);
+      }
+    }
+  }
+  range.setValues(cells);
+}


### PR DESCRIPTION
便利なアドオンをありがとうございます。以下のように欲しくなった機能を追加しました。ご検討よろしくおねがいします。
* 日付のスライド機能
  - スライドさせたい日付セルを選択し（範囲選択可能）、サイドメニューから日数を選択し実行することで一括に日付を操作します。
  - 日付の操作後、チャートの再色塗りを実行します。
  - ※Ctrlを使って複数範囲を選択した場合は最後に選択した範囲のみ操作されます。これはgetActiveRange()関数の仕様のようです。
* CSSの微修正
  - 縦の短い画面を使っているとき、作者名の表示がUIと重なったままとなっていたので、スクロールに追従するように変更しました。